### PR TITLE
URxvt: allow scrolling back while receiving output

### DIFF
--- a/Resources/Defaults/Settings/skel/.Xresources
+++ b/Resources/Defaults/Settings/skel/.Xresources
@@ -16,6 +16,10 @@ URxvt.saveLines: 100000
 URxvt.internalBorder: 0
 URxvt.termName: rxvt
 
+URxvt*scrollTtyOutput: false
+URxvt*scrollWithBuffer: true
+URxvt*scrollTtyKeypress: true
+
 URxvt.clipboard.autocopy: true
 URxvt.keysym.S-Insert: \033[2$
 URxvt.keysym.C-S-Up: \033[1;6A


### PR DESCRIPTION
By default URxvt immediately jumps to the bottom of the buffer when receiving output.
This commit allows you to scoll back to see previous output.
URxvt will still auto-scroll when it's a the bottom of the output.

@lucasvr, @hishamhm I think this is a very convenient feature but please let me know of your opinion whether you want it merged :)